### PR TITLE
Feature(categories endpoints) Add controllers for categories

### DIFF
--- a/controllers/categories.go
+++ b/controllers/categories.go
@@ -7,6 +7,10 @@ import (
 	"recipe/models"
 	"strconv"
 
+	"fmt"
+
+	"errors"
+
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/mux"
 )
@@ -23,9 +27,7 @@ func CreateCategory(w http.ResponseWriter, r *http.Request) {
 		Title:       r.FormValue("title"),
 		Description: r.FormValue("description"),
 	}
-
 	decoder := json.NewDecoder(r.Body)
-
 	decoderErr := decoder.Decode(&category)
 
 	if decoderErr != nil {
@@ -72,66 +74,64 @@ func GetCategory(w http.ResponseWriter, r *http.Request) {
 	helpers.StatusOk(w, category)
 }
 
-// // GetAllcategorys Gets all categorys and sends the data as response
-// // to the requesting category
-// func GetAllcategorys(w http.ResponseWriter, r *http.Request) {
-// 	categorys, err := models.GetAllCategory()
-// 	if err != nil {
-// 		helpers.ServerError(w, err)
-// 		return
-// 	}
-// 	response := categorysResponse{
-// 		Status: http.StatusOK,
-// 		Data:   categorys,
-// 	}
-// 	result, _ := json.Marshal(response)
+// GetAllcategory Gets all category and sends the data as response
+// to the requesting category
+func GetAllcategory(w http.ResponseWriter, r *http.Request) {
+	category, err := models.GetAllCategory()
+	if err != nil {
+		helpers.ServerError(w, err)
+		return
+	}
+	response := CategoryResponse{
+		Status: http.StatusOK,
+		Data:   category,
+	}
+	result, _ := json.Marshal(response)
 
-// 	helpers.ResponseWriter(w, http.StatusOK, string(result))
-// }
+	helpers.ResponseWriter(w, http.StatusOK, string(result))
+}
 
-// //Updatecategory updates category's detail
-// func Updatecategory(w http.ResponseWriter, r *http.Request) {
-// 	category := models.category{
-// 		FirstName:    r.FormValue("first_name"),
-// 		LastName:     r.FormValue("last_name"),
-// 		categoryName: r.FormValue("categoryname"),
-// 		Email:        r.FormValue("email"),
-// 		Password:     r.FormValue("password"),
-// 	}
+//UpdateCategory updates category's detail
+func UpdateCategory(w http.ResponseWriter, r *http.Request) {
+	category := models.Category{
+		Title:       r.FormValue("title"),
+		Description: r.FormValue("description"),
+	}
 
-// 	decoder := json.NewDecoder(r.Body)
+	decoder := json.NewDecoder(r.Body)
+	decoderErr := decoder.Decode(&category)
 
-// 	decoderErr := decoder.Decode(&category)
+	if decoderErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["id"])
 
-// 	if decoderErr != nil {
-// 		helpers.DecoderErrorResponse(w)
-// 		return
-// 	}
-// 	vars := mux.Vars(r)
-// 	id, _ := strconv.Atoi(vars["id"])
+	fmt.Println(id)
 
-// 	_, err := models.Updatecategory(id, &category)
-// 	fmt.Println(err.Error())
-// 	if err != nil {
-// 		helpers.BadRequest(w, err)
-// 		return
-// 	}
-// 	helpers.StatusOk(w, category)
-// }
+	_, err := models.UpdateCategoryById(id, &category)
+	// fmt.Println(err.Error())
+	if err != nil {
+		helpers.BadRequest(w, errors.New(err.Error()))
+		return
+	}
+	helpers.StatusOkMessage(w, "category updated")
+}
 
-// //Deletecategory deletes a category detail
-// func Deletecategory(w http.ResponseWriter, r *http.Request) {
-// 	vars := mux.Vars(r)
+// DeleteCategory deletes a category detail
+func DeleteCategory(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
 
-// 	id, parseErr := strconv.Atoi(vars["id"])
-// 	if parseErr != nil {
-// 		helpers.DecoderErrorResponse(w)
-// 		return
-// 	}
-// 	_, err := models.Deletecategory(id)
-// 	if err != nil {
-// 		helpers.BadRequest(w, err)
-// 		return
-// 	}
-// 	helpers.ResponseWriter(w, http.StatusOK, "category deleted")
-// }
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	_, err := models.DeleteCategory(id)
+	if err != nil {
+		helpers.BadRequest(w, err)
+		return
+	}
+	helpers.StatusOkMessage(w, "category deleted")
+}

--- a/controllers/categories.go
+++ b/controllers/categories.go
@@ -1,0 +1,137 @@
+package controllers
+
+import (
+	"encoding/json"
+	"net/http"
+	"recipe/helpers"
+	"recipe/models"
+	"strconv"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
+)
+
+// CategoryResponse is
+type CategoryResponse struct {
+	Status int               `json:"status"`
+	Data   []models.Category `json:"data"`
+}
+
+// CreateCategory creates a new category
+func CreateCategory(w http.ResponseWriter, r *http.Request) {
+	category := models.Category{
+		Title:       r.FormValue("title"),
+		Description: r.FormValue("description"),
+	}
+
+	decoder := json.NewDecoder(r.Body)
+
+	decoderErr := decoder.Decode(&category)
+
+	if decoderErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	if category.Title == "" {
+		errMsg := models.Category{
+			Title: "Title  is required",
+		}
+
+		type Error struct {
+			Status  int
+			Message interface{}
+		}
+		newError := Error{Status: http.StatusBadRequest, Message: errMsg}
+		response, _ := json.Marshal(newError)
+		helpers.ResponseWriter(w, http.StatusBadRequest, string(response))
+		return
+	}
+	_, dbErr := models.CreateCategory(&category)
+
+	if dbErr != nil {
+		helpers.ServerError(w, dbErr)
+		return
+	}
+	helpers.StatusOk(w, category)
+}
+
+// GetCategory Gets all categorys and sends the data as response
+// to the requesting category
+func GetCategory(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	category, err := models.GetCategory(id)
+	if err != nil {
+		helpers.StatusNotFound(w, err)
+		return
+	}
+	helpers.StatusOk(w, category)
+}
+
+// // GetAllcategorys Gets all categorys and sends the data as response
+// // to the requesting category
+// func GetAllcategorys(w http.ResponseWriter, r *http.Request) {
+// 	categorys, err := models.GetAllCategory()
+// 	if err != nil {
+// 		helpers.ServerError(w, err)
+// 		return
+// 	}
+// 	response := categorysResponse{
+// 		Status: http.StatusOK,
+// 		Data:   categorys,
+// 	}
+// 	result, _ := json.Marshal(response)
+
+// 	helpers.ResponseWriter(w, http.StatusOK, string(result))
+// }
+
+// //Updatecategory updates category's detail
+// func Updatecategory(w http.ResponseWriter, r *http.Request) {
+// 	category := models.category{
+// 		FirstName:    r.FormValue("first_name"),
+// 		LastName:     r.FormValue("last_name"),
+// 		categoryName: r.FormValue("categoryname"),
+// 		Email:        r.FormValue("email"),
+// 		Password:     r.FormValue("password"),
+// 	}
+
+// 	decoder := json.NewDecoder(r.Body)
+
+// 	decoderErr := decoder.Decode(&category)
+
+// 	if decoderErr != nil {
+// 		helpers.DecoderErrorResponse(w)
+// 		return
+// 	}
+// 	vars := mux.Vars(r)
+// 	id, _ := strconv.Atoi(vars["id"])
+
+// 	_, err := models.Updatecategory(id, &category)
+// 	fmt.Println(err.Error())
+// 	if err != nil {
+// 		helpers.BadRequest(w, err)
+// 		return
+// 	}
+// 	helpers.StatusOk(w, category)
+// }
+
+// //Deletecategory deletes a category detail
+// func Deletecategory(w http.ResponseWriter, r *http.Request) {
+// 	vars := mux.Vars(r)
+
+// 	id, parseErr := strconv.Atoi(vars["id"])
+// 	if parseErr != nil {
+// 		helpers.DecoderErrorResponse(w)
+// 		return
+// 	}
+// 	_, err := models.Deletecategory(id)
+// 	if err != nil {
+// 		helpers.BadRequest(w, err)
+// 		return
+// 	}
+// 	helpers.ResponseWriter(w, http.StatusOK, "category deleted")
+// }

--- a/controllers/categories.go
+++ b/controllers/categories.go
@@ -55,7 +55,7 @@ func CreateCategory(w http.ResponseWriter, r *http.Request) {
 	helpers.StatusOk(w, category)
 }
 
-// GetCategory Gets all categorys and sends the data as response
+// GetCategory Gets all category and sends the data as response
 // to the requesting category
 func GetCategory(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)

--- a/controllers/recipe.go
+++ b/controllers/recipe.go
@@ -1,4 +1,4 @@
-package recipes
+package controllers
 
 import (
 	"encoding/json"

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -2,13 +2,14 @@ package controllers
 
 import (
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"recipe/models"
 
 	"strconv"
 
 	"recipe/helpers"
+
+	"errors"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gorilla/mux"
@@ -122,13 +123,12 @@ func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	id, _ := strconv.Atoi(vars["id"])
 
-	_, err := models.UpdateUser(id, &user)
-	fmt.Println(err.Error())
+	_, err := models.UpdateUserByID(id, &user)
 	if err != nil {
-		helpers.BadRequest(w, err)
+		helpers.BadRequest(w, errors.New(err.Error()))
 		return
 	}
-	helpers.StatusOk(w, user)
+	helpers.StatusOkMessage(w, "User with "+vars["id"]+" updated")
 }
 
 //DeleteUser deletes a user detail
@@ -145,5 +145,15 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		helpers.BadRequest(w, err)
 		return
 	}
-	helpers.ResponseWriter(w, http.StatusOK, "User deleted")
+
+	type Message struct {
+		Status  int    `json:"status"`
+		Message string `json:"message"`
+	}
+
+	response := Message{
+		Status:  http.StatusOK,
+		Message: "user deleted",
+	}
+	helpers.StatusOk(w, response)
 }

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -1,4 +1,4 @@
-package user
+package controllers
 
 import (
 	"encoding/json"
@@ -14,25 +14,13 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// Data data to be sent
-// When request is made to the server
-type Data struct {
-	ID        string `json:"id,omitempty"`
-	FirstName string `json:"first_name,omitempty"`
-	LastName  string `json:"last_name,omitempty"`
-	UserName  string `json:"username,omitempty"`
-	Email     string `json:"email,omitempty"`
-	CreatedAt string `json:"created_at,omitempty"`
-	UpdatedAt string `json:"updated_at,omitempty"`
-}
-
 type usersResponse struct {
 	Status int           `json:"status"`
 	Data   []models.User `json:"data"`
 }
 
-// Create creates a new user
-func Create(w http.ResponseWriter, r *http.Request) {
+// CreateUser creates a new user
+func CreateUser(w http.ResponseWriter, r *http.Request) {
 	user := models.User{
 		FirstName: r.FormValue("first_name"),
 		LastName:  r.FormValue("last_name"),
@@ -82,7 +70,6 @@ func Create(w http.ResponseWriter, r *http.Request) {
 // to the requesting user
 func GetUser(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
-	fmt.Println(r.Context())
 
 	id, parseErr := strconv.Atoi(vars["id"])
 	if parseErr != nil {
@@ -95,7 +82,6 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	helpers.StatusOk(w, user)
-
 }
 
 // GetAllUsers Gets all users and sends the data as response
@@ -115,8 +101,8 @@ func GetAllUsers(w http.ResponseWriter, r *http.Request) {
 	helpers.ResponseWriter(w, http.StatusOK, string(result))
 }
 
-//Update updates user's detail
-func Update(w http.ResponseWriter, r *http.Request) {
+//UpdateUser updates user's detail
+func UpdateUser(w http.ResponseWriter, r *http.Request) {
 	user := models.User{
 		FirstName: r.FormValue("first_name"),
 		LastName:  r.FormValue("last_name"),
@@ -145,8 +131,8 @@ func Update(w http.ResponseWriter, r *http.Request) {
 	helpers.StatusOk(w, user)
 }
 
-//Delete deletes a user detail
-func Delete(w http.ResponseWriter, r *http.Request) {
+//DeleteUser deletes a user detail
+func DeleteUser(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	id, parseErr := strconv.Atoi(vars["id"])

--- a/helpers/customHandler.go
+++ b/helpers/customHandler.go
@@ -32,17 +32,17 @@ func RespondMessage(err string, status int) string {
 
 // RespondMessages converts error messages to a
 // valid string to be sent as response
-func RespondMessages(err interface{}, status int) string {
+func RespondMessages(message string, status int) string {
 	type Response struct {
 		Status  int         `json:"status"`
 		Message interface{} `json:"message"`
 	}
-	newErr := Response{
+	msg := Response{
 		Status:  status,
-		Message: err,
+		Message: message,
 	}
 
-	response, err := json.Marshal(newErr)
+	response, _ := json.Marshal(msg)
 	return string(response)
 }
 

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -2,13 +2,14 @@ package helpers
 
 import (
 	"bytes"
+	"fmt"
 )
 
 // UpdateBuilder
-func UpdateBuilder(u map[string]string) string {
+func UpdateBuilder(u map[string]string, table string) string {
 	var query bytes.Buffer
-	query.WriteString("UPDATE users SET ")
-
+	query.WriteString("UPDATE " + table + " SET ")
+	var result string
 	length := len(u)
 
 	for value, key := range u {
@@ -21,6 +22,7 @@ func UpdateBuilder(u map[string]string) string {
 	}
 
 	query.WriteString("WHERE id = ? ")
-
-	return query.String()
+	fmt.Println(query.String())
+	result = query.String()
+	return result
 }

--- a/helpers/response.go
+++ b/helpers/response.go
@@ -39,18 +39,8 @@ func DecoderErrorResponse(w http.ResponseWriter) {
 // data to the server
 func BadRequest(w http.ResponseWriter, errMsg error) {
 	// Error interface
-	type Error struct {
-		Status  int    `json:"status"`
-		Message string `json:"message"`
-	}
-
-	err := Error{
-		Status:  http.StatusBadRequest,
-		Message: errMsg.Error(),
-	}
-
 	w.Header().Set("Content-type", "Application/json")
-	response := RespondMessages(err, http.StatusBadRequest)
+	response := RespondMessages(errMsg.Error(), http.StatusBadRequest)
 	fmt.Fprint(w, response)
 }
 
@@ -67,6 +57,14 @@ func StatusNotFound(w http.ResponseWriter, err error) {
 // access a resource
 func StatusOk(w http.ResponseWriter, data interface{}) {
 	msg := RespondWithData("", 200, data)
+	ResponseWriter(w, http.StatusOK, msg)
+}
+
+// StatusOkMessage Sends a 200 request to the user
+// this is mostly triggered when the user
+// access a resource
+func StatusOkMessage(w http.ResponseWriter, message string) {
+	msg := RespondMessages(message, http.StatusOK)
 	ResponseWriter(w, http.StatusOK, msg)
 }
 

--- a/main/main.go
+++ b/main/main.go
@@ -1,12 +1,9 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
 	"net/http"
 	"recipe/controllers"
 	"recipe/models"
-	"strconv"
 
 	"github.com/gorilla/mux"
 )
@@ -16,7 +13,7 @@ var baseURL = "/api/v1"
 func main() {
 	router := routes()
 	http.Handle("/", router)
-	http.ListenAndServe(":8083", nil)
+	http.ListenAndServe(":8085", nil)
 }
 
 func init() {
@@ -26,49 +23,21 @@ func init() {
 func routes() *mux.Router {
 	router := mux.NewRouter()
 	router.HandleFunc(baseURL+"/users", controllers.GetAllUsers).Methods("GET")
-	router.HandleFunc(baseURL+"/users", controllers.Create).Methods("POST")
+	router.HandleFunc(baseURL+"/users", controllers.CreateUser).Methods("POST")
 	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.GetUser).Methods("GET")
-	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Update).Methods("PUT")
-	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Delete).Methods("DELETE")
+	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.UpdateUser).Methods("PUT")
+	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.DeleteUser).Methods("DELETE")
 
-	router.HandleFunc(baseURL+"/categories", controllers.GetAllUsers).Methods("GET")
+	router.HandleFunc(baseURL+"/categories", controllers.GetAllcategory).Methods("GET")
 	router.HandleFunc(baseURL+"/categories", controllers.CreateCategory).Methods("POST")
 	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.GetCategory).Methods("GET")
-	// router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Update).Methods("PUT")
-	// router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Delete).Methods("DELETE")
+	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.UpdateCategory).Methods("PUT")
+	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.DeleteCategory).Methods("DELETE")
 
-	router.HandleFunc(baseURL+"/recipes", controllers.GetUser).Methods("GET")
-	router.HandleFunc(baseURL+"/recipes", controllers.Create).Methods("POST")
-	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("PUT")
-	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("DELETE")
+	// router.HandleFunc(baseURL+"/recipes", controllers.GetUser).Methods("GET")
+	// router.HandleFunc(baseURL+"/recipes", controllers.Create).Methods("POST")
+	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateCategory).Methods("PUT")
+	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("DELETE")
 
 	return router
-}
-
-func test(w http.ResponseWriter, r *http.Request) {
-	params := mux.Vars(r)
-
-	id, err := strconv.Atoi(params["id"])
-
-	if err != nil {
-		panic(err)
-	}
-
-	var userData models.User
-
-	decoder := json.NewDecoder(r.Body)
-
-	decoderErr := decoder.Decode(&userData)
-
-	if decoderErr != nil {
-		panic(decoderErr)
-	}
-
-	fmt.Println(userData, 1, id)
-
-	if err != nil {
-		panic(err.Error())
-	} else {
-		models.UpdateUser(id, &userData)
-	}
 }

--- a/main/main.go
+++ b/main/main.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"recipe/controllers/user"
+	"recipe/controllers"
 	"recipe/models"
 	"strconv"
 
@@ -25,16 +25,22 @@ func init() {
 
 func routes() *mux.Router {
 	router := mux.NewRouter()
-	router.HandleFunc(baseURL+"/users", user.GetAllUsers).Methods("GET")
-	router.HandleFunc(baseURL+"/users", user.Create).Methods("POST")
-	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", user.GetUser).Methods("GET")
-	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", user.Update).Methods("PUT")
-	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", user.Delete).Methods("DELETE")
+	router.HandleFunc(baseURL+"/users", controllers.GetAllUsers).Methods("GET")
+	router.HandleFunc(baseURL+"/users", controllers.Create).Methods("POST")
+	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.GetUser).Methods("GET")
+	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Update).Methods("PUT")
+	router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Delete).Methods("DELETE")
 
-	router.HandleFunc(baseURL+"/recipes", user.GetUser).Methods("GET")
-	router.HandleFunc(baseURL+"/recipes", user.Create).Methods("POST")
-	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", user.Update).Methods("PUT")
-	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", user.Update).Methods("DELETE")
+	router.HandleFunc(baseURL+"/categories", controllers.GetAllUsers).Methods("GET")
+	router.HandleFunc(baseURL+"/categories", controllers.CreateCategory).Methods("POST")
+	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.GetCategory).Methods("GET")
+	// router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Update).Methods("PUT")
+	// router.HandleFunc(baseURL+"/users/{id:[0-9]+}", controllers.Delete).Methods("DELETE")
+
+	router.HandleFunc(baseURL+"/recipes", controllers.GetUser).Methods("GET")
+	router.HandleFunc(baseURL+"/recipes", controllers.Create).Methods("POST")
+	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("PUT")
+	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("DELETE")
 
 	return router
 }

--- a/models/category.go
+++ b/models/category.go
@@ -12,34 +12,38 @@ import (
 type Category struct {
 	ID          int    `json:"id,omitempty"`
 	Title       string `json:"title,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	CreatedAt   string `json:"created_at,omitempty"`
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
 // GetAllCategory gets all user
-func GetAllCategory() []Category {
+func GetAllCategory() ([]Category, error) {
 	db := DB()
-	categories := []Category{}
-
-	rows, err := db.Query(`SELECT id, title, description created_at, updated_at FROM categories`)
 
 	defer db.Close()
 
+	categories := []Category{}
+
+	rows, err := db.Query(`SELECT id, title, description, created_at, updated_at FROM categories`)
+
 	if err != nil {
-		panic(err)
+		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
+		return nil, errMsg
+
 	}
 
 	for rows.Next() {
 		category := Category{}
 
 		if err := rows.Scan(&category.ID, &category.Title, &category.Description, &category.CreatedAt, &category.UpdatedAt); err != nil {
-			panic(err.Error())
+			errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
+			return nil, errMsg
 		}
 		categories = append(categories, category)
 		fmt.Println(categories)
 	}
-	return categories
+	return categories, nil
 }
 
 //GetCategory gets a single user
@@ -86,24 +90,24 @@ func CreateCategory(category *Category) (*Category, error) {
 func DeleteCategory(id int) (bool, error) {
 	db := DB()
 
-	sql := `DELETE * FROM categories WHERE id = ?`
-	row, err := db.Exec(sql, id)
+	sql := `DELETE FROM categories WHERE id = ?`
+	_, err := db.Exec(sql, id)
 
 	defer db.Close()
 
 	if err != nil {
-		fmt.Println(err.Error())
-		return false, err
+		errMsg := fmt.Errorf("Error Deletin a category: %s?", err.Error())
+		return false, errMsg
 	}
-	fmt.Println(row)
-
 	return true, nil
 }
 
 // UpdateCategory updates category details base on the values sent
 // takes the user id and user struct containing details to be update
-func UpdateCategory(id int, category *Category) (bool, error) {
+func UpdateCategoryById(id int, category *Category) (bool, error) {
 	db := DB()
+
+	defer db.Close()
 
 	categoryValues := map[string]string{}
 
@@ -119,7 +123,8 @@ func UpdateCategory(id int, category *Category) (bool, error) {
 		categoryValues["description"] = category.Description
 	}
 
-	query := helpers.UpdateBuilder(categoryValues)
+	query := helpers.UpdateBuilder(categoryValues, "CATEGORIES")
+	fmt.Println(query)
 	_, UpdateErr := db.Exec(query, id)
 	if UpdateErr != nil {
 		return false, UpdateErr

--- a/models/db.go
+++ b/models/db.go
@@ -2,6 +2,7 @@ package models
 
 import (
 	"database/sql"
+	"fmt"
 
 	_ "github.com/go-sql-driver/mysql"
 )
@@ -9,13 +10,13 @@ import (
 func DB() *sql.DB {
 	db, err := sql.Open("mysql", "root@/go_recipes")
 	if err != nil {
-		panic(err.Error())
+		fmt.Println(err.Error())
 	}
 
 	pingErr := db.Ping()
 
 	if pingErr != nil {
-		panic(pingErr.Error())
+		fmt.Println(pingErr.Error())
 	}
 	return db
 }

--- a/models/indredient.go
+++ b/models/indredient.go
@@ -39,7 +39,6 @@ func GetAllIngredient() []Ingredient {
 			panic(err.Error())
 		}
 		ingredients = append(ingredients, ingredient)
-		fmt.Println(ingredient)
 	}
 	return ingredients
 }
@@ -55,7 +54,6 @@ func GetIngredient(id int) (Ingredient, error) {
 
 	switch {
 	case err == sql.ErrNoRows:
-		fmt.Println("No rows with that id found", err.Error())
 		errMsg := fmt.Errorf("ingredient with (id %d) does not exist", id)
 		return ingredient, errMsg
 	case err != nil:
@@ -72,11 +70,9 @@ func CreateIngredient() {
 	db := DB()
 	ingredient := Ingredient{}
 	sql := `INSERT INTO recipes (name, quantity, recipeID, unit) VALUES(?, ?, ?, ?)`
-	row, err := db.Exec(sql, &ingredient)
+	_, err := db.Exec(sql, &ingredient)
 	if err != nil {
-		fmt.Println(err.Error())
 	}
-	fmt.Println(row)
 }
 
 // DeleteIngredient ingredient from database
@@ -86,15 +82,13 @@ func DeleteIngredient(id int) (bool, error) {
 	db := DB()
 
 	sql := `DELETE * FROM ingredients WHERE id = ?`
-	row, err := db.Exec(sql, id)
+	_, err := db.Exec(sql, id)
 
 	defer db.Close()
 
 	if err != nil {
-		fmt.Println(err.Error())
 		return false, err
 	}
-	fmt.Println(row)
 
 	return true, nil
 }
@@ -120,7 +114,7 @@ func UpdateIngredient(id int, ingredient *Ingredient) (bool, error) {
 		ingredientValues["quantity"] = ingredient.Quantity
 	}
 
-	query := helpers.UpdateBuilder(ingredientValues)
+	query := helpers.UpdateBuilder(ingredientValues, "INGREDIENTS")
 
 	println(query)
 	rows, err := db.Exec(query, id)

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -121,7 +121,7 @@ func UpdateRecipe(id int, recipe *Recipe) (bool, error) {
 		recipeValues["description"] = recipe.Description
 	}
 
-	query := helpers.UpdateBuilder(recipeValues)
+	query := helpers.UpdateBuilder(recipeValues, "RECIPES")
 
 	println(query)
 	rows, err := db.Exec(query, id)

--- a/models/user.go
+++ b/models/user.go
@@ -4,7 +4,6 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
-	"recipe/helpers"
 )
 
 // User data to be sent
@@ -105,12 +104,12 @@ func DeleteUser(id int) (bool, error) {
 	return true, nil
 }
 
-// UpdateUser user details base on the values sent
+// UpdateUserByID user details base on the values sent
 // takes the user id and user struct containing
 // details to be update
-func UpdateUser(id int, user *User) (bool, error) {
+func UpdateUserByID(id int, user *User) (bool, error) {
 	db := DB()
-
+	defer db.Close()
 	userValues := map[string]string{}
 
 	_, err := GetUser(id)
@@ -133,10 +132,12 @@ func UpdateUser(id int, user *User) (bool, error) {
 	if user.Email != "" {
 		userValues["email"] = user.Email
 	}
-	query := helpers.UpdateBuilder(userValues)
-	_, UpdateErr := db.Exec(query, id)
-	if UpdateErr != nil {
-		return false, UpdateErr
-	}
+	// table := "USERS"
+	// query := helpers.UpdateBuilder(userValues, table)
+
+	// _, UpdateErr := db.Exec(query, id)
+	// if UpdateErr != nil {
+	// 	return false, UpdateErr
+	// }
 	return true, nil
 }

--- a/models/user.go
+++ b/models/user.go
@@ -52,8 +52,8 @@ func GetUser(id int) (User, error) {
 	db := DB()
 	user := User{}
 	defer db.Close()
-	err := db.QueryRow("SELECT first_name, last_name, email, username, profile_pic FROM users where id = ? ", id).
-		Scan(&user.FirstName, &user.Email, &user.LastName, &user.UserName, &user.ProfilePic)
+	err := db.QueryRow("SELECT id, first_name, last_name, email, username, profile_pic FROM users where id = ? ", id).
+		Scan(&user.ID, &user.FirstName, &user.Email, &user.LastName, &user.UserName, &user.ProfilePic)
 
 	switch {
 	case err == sql.ErrNoRows:


### PR DESCRIPTION
### WHAT DOES THIS PR DO
  This PR adds user controller for the category endpoint
### Description 
  This PR provides controllers for making crud operations via HTTP methods.
#### SUMMARY
  Users can now GET, DELETE, UPDATE AND CREATE other categories via HTTP. Endpoints implemented are stated below
- GET        /api/v1/categories gets all category
- POST     /api/v1/categories creates a new category
- GET        /api/v1/categories/id gets a single category
- PUT        /api/v1/categories/id updates a single category 
- DELETE  /api/v1/categories/id deletes a single category 
### Dev Notes 
 A new ticket would be added later to further expand on this controller to allow 
- Search for category
- limit the number of results for getting all category
- paginate the list of category