### PR TITLE
Feature(recipes endpoints) Add controllers for recipes

### DIFF
--- a/controllers/categories.go
+++ b/controllers/categories.go
@@ -51,7 +51,7 @@ func CreateCategory(w http.ResponseWriter, r *http.Request) {
 	_, dbErr := models.CreateCategory(&category)
 
 	if dbErr != nil {
-		helpers.ServerError(w, dbErr)
+		helpers.ServerError(w, errors.New(dbErr.Error()))
 		return
 	}
 	helpers.StatusOk(w, category)

--- a/controllers/recipe.go
+++ b/controllers/recipe.go
@@ -2,6 +2,8 @@ package controllers
 
 import (
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"recipe/helpers"
 	"recipe/models"
@@ -23,6 +25,7 @@ func CreateRecipe(w http.ResponseWriter, r *http.Request) {
 		Name:        r.FormValue("name"),
 		UserID:      r.FormValue("userID"),
 		CategoryID:  r.FormValue("categoryID"),
+		Image:       r.FormValue("image_url"),
 		Description: r.FormValue("description"),
 	}
 	decoder := json.NewDecoder(r.Body)
@@ -73,64 +76,65 @@ func GetRecipe(w http.ResponseWriter, r *http.Request) {
 	helpers.StatusOk(w, Recipe)
 }
 
-// // GetAllRecipe Gets all Recipe and sends the data as response
-// // to the requesting Recipe
-// func GetAllRecipe(w http.ResponseWriter, r *http.Request) {
-// 	Recipe, err := models.GetAllRecipe()
-// 	if err != nil {
-// 		helpers.ServerError(w, err)
-// 		return
-// 	}
-// 	response := RecipeResponse{
-// 		Status: http.StatusOK,
-// 		Data:   Recipe,
-// 	}
-// 	result, _ := json.Marshal(response)
+// GetAllRecipe Gets all Recipe and sends the data as response
+// to the requesting Recipe
+func GetAllRecipe(w http.ResponseWriter, r *http.Request) {
+	Recipe, err := models.GetAllRecipe()
+	if err != nil {
+		helpers.ServerError(w, err)
+		return
+	}
+	response := RecipeResponse{
+		Status: http.StatusOK,
+		Data:   Recipe,
+	}
+	result, _ := json.Marshal(response)
 
-// 	helpers.ResponseWriter(w, http.StatusOK, string(result))
-// }
+	helpers.ResponseWriter(w, http.StatusOK, string(result))
+}
 
-// //UpdateRecipe updates Recipe's detail
-// func UpdateRecipe(w http.ResponseWriter, r *http.Request) {
-// 	Recipe := models.Recipe{
-// 		Title:       r.FormValue("title"),
-// 		Description: r.FormValue("description"),
-// 	}
+//UpdateRecipe updates Recipe's detail
+func UpdateRecipe(w http.ResponseWriter, r *http.Request) {
+	Recipe := models.Recipe{
+		Name:        r.FormValue("name"),
+		UserID:      r.FormValue("userID"),
+		CategoryID:  r.FormValue("categoryID"),
+		Image:       r.FormValue("image_url"),
+		Description: r.FormValue("description"),
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoderErr := decoder.Decode(&Recipe)
 
-// 	decoder := json.NewDecoder(r.Body)
-// 	decoderErr := decoder.Decode(&Recipe)
+	if decoderErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["id"])
 
-// 	if decoderErr != nil {
-// 		helpers.DecoderErrorResponse(w)
-// 		return
-// 	}
-// 	vars := mux.Vars(r)
-// 	id, _ := strconv.Atoi(vars["id"])
+	fmt.Println(id)
 
-// 	fmt.Println(id)
+	_, err := models.UpdateRecipe(id, &Recipe)
+	if err != nil {
+		helpers.BadRequest(w, errors.New(err.Error()))
+		return
+	}
+	helpers.StatusOkMessage(w, "Recipe updated")
+}
 
-// 	_, err := models.UpdateRecipeById(id, &Recipe)
-// 	// fmt.Println(err.Error())
-// 	if err != nil {
-// 		helpers.BadRequest(w, errors.New(err.Error()))
-// 		return
-// 	}
-// 	helpers.StatusOkMessage(w, "Recipe updated")
-// }
+// DeleteRecipe deletes a Recipe detail
+func DeleteRecipe(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
 
-// // DeleteRecipe deletes a Recipe detail
-// func DeleteRecipe(w http.ResponseWriter, r *http.Request) {
-// 	vars := mux.Vars(r)
-
-// 	id, parseErr := strconv.Atoi(vars["id"])
-// 	if parseErr != nil {
-// 		helpers.DecoderErrorResponse(w)
-// 		return
-// 	}
-// 	_, err := models.DeleteRecipe(id)
-// 	if err != nil {
-// 		helpers.BadRequest(w, err)
-// 		return
-// 	}
-// 	helpers.StatusOkMessage(w, "Recipe deleted")
-// }
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	_, err := models.DeleteRecipe(id)
+	if err != nil {
+		helpers.BadRequest(w, err)
+		return
+	}
+	helpers.StatusOkMessage(w, "Recipe deleted")
+}

--- a/controllers/recipe.go
+++ b/controllers/recipe.go
@@ -5,8 +5,10 @@ import (
 	"net/http"
 	"recipe/helpers"
 	"recipe/models"
+	"strconv"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
 )
 
 // RecipeResponse is
@@ -54,22 +56,22 @@ func CreateRecipe(w http.ResponseWriter, r *http.Request) {
 	helpers.StatusOkMessage(w, "Recipe created")
 }
 
-// // GetRecipe Gets all Recipe and sends the data as response
-// // to the requesting Recipe
-// func GetRecipe(w http.ResponseWriter, r *http.Request) {
-// 	vars := mux.Vars(r)
-// 	id, parseErr := strconv.Atoi(vars["id"])
-// 	if parseErr != nil {
-// 		helpers.DecoderErrorResponse(w)
-// 		return
-// 	}
-// 	Recipe, err := models.GetRecipe(id)
-// 	if err != nil {
-// 		helpers.StatusNotFound(w, err)
-// 		return
-// 	}
-// 	helpers.StatusOk(w, Recipe)
-// }
+// GetRecipe Gets all Recipe and sends the data as response
+// to the requesting Recipe
+func GetRecipe(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	Recipe, err := models.GetRecipe(id)
+	if err != nil {
+		helpers.StatusNotFound(w, err)
+		return
+	}
+	helpers.StatusOk(w, Recipe)
+}
 
 // // GetAllRecipe Gets all Recipe and sends the data as response
 // // to the requesting Recipe

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -145,15 +145,5 @@ func DeleteUser(w http.ResponseWriter, r *http.Request) {
 		helpers.BadRequest(w, err)
 		return
 	}
-
-	type Message struct {
-		Status  int    `json:"status"`
-		Message string `json:"message"`
-	}
-
-	response := Message{
-		Status:  http.StatusOK,
-		Message: "user deleted",
-	}
-	helpers.StatusOk(w, response)
+	helpers.StatusOkMessage(w, "user with id"+vars["id"]+"deleted")
 }

--- a/main/main.go
+++ b/main/main.go
@@ -35,11 +35,11 @@ func routes() *mux.Router {
 	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.UpdateCategory).Methods("PUT")
 	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.DeleteCategory).Methods("DELETE")
 
-	// router.HandleFunc(baseURL+"/recipes", controllers.GetRecipe).Methods("GET")
+	router.HandleFunc(baseURL+"/recipes", controllers.GetAllRecipe).Methods("GET")
 	router.HandleFunc(baseURL+"/recipes", controllers.CreateRecipe).Methods("POST")
 	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.GetRecipe).Methods("GET")
-	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateRecipe).Methods("PUT")
-	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.DeleteRecipe).Methods("DELETE")
+	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateRecipe).Methods("PUT")
+	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.DeleteRecipe).Methods("DELETE")
 
 	return router
 }

--- a/main/main.go
+++ b/main/main.go
@@ -37,7 +37,7 @@ func routes() *mux.Router {
 
 	// router.HandleFunc(baseURL+"/recipes", controllers.GetRecipe).Methods("GET")
 	router.HandleFunc(baseURL+"/recipes", controllers.CreateRecipe).Methods("POST")
-	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.GetRecipe).Methods("GET")
+	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.GetRecipe).Methods("GET")
 	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateRecipe).Methods("PUT")
 	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.DeleteRecipe).Methods("DELETE")
 

--- a/main/main.go
+++ b/main/main.go
@@ -35,10 +35,11 @@ func routes() *mux.Router {
 	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.UpdateCategory).Methods("PUT")
 	router.HandleFunc(baseURL+"/categories/{id:[0-9]+}", controllers.DeleteCategory).Methods("DELETE")
 
-	// router.HandleFunc(baseURL+"/recipes", controllers.GetUser).Methods("GET")
-	// router.HandleFunc(baseURL+"/recipes", controllers.Create).Methods("POST")
-	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateCategory).Methods("PUT")
-	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.Update).Methods("DELETE")
+	// router.HandleFunc(baseURL+"/recipes", controllers.GetRecipe).Methods("GET")
+	router.HandleFunc(baseURL+"/recipes", controllers.CreateRecipe).Methods("POST")
+	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.GetRecipe).Methods("GET")
+	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateRecipe).Methods("PUT")
+	// router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.DeleteRecipe).Methods("DELETE")
 
 	return router
 }

--- a/models/category.go
+++ b/models/category.go
@@ -17,7 +17,7 @@ type Category struct {
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
 
-// GetAllCategory gets all user
+// GetAllCategory gets all category
 func GetAllCategory() ([]Category, error) {
 	db := DB()
 
@@ -46,7 +46,7 @@ func GetAllCategory() ([]Category, error) {
 	return categories, nil
 }
 
-//GetCategory gets a single user
+//GetCategory gets a single category
 func GetCategory(id int) (Category, error) {
 	db := DB()
 	defer db.Close()
@@ -71,7 +71,7 @@ func GetCategory(id int) (Category, error) {
 	}
 }
 
-//CreateCategory creates a new user
+//CreateCategory creates a new category
 func CreateCategory(category *Category) (*Category, error) {
 	db := DB()
 	defer db.Close()
@@ -84,8 +84,8 @@ func CreateCategory(category *Category) (*Category, error) {
 	return category, nil
 }
 
-// DeleteCategory user from database
-// NB: this method wipes all user details
+// DeleteCategory category from database
+// NB: this method wipes all category details
 // recipe ans ingredients inclusive
 func DeleteCategory(id int) (bool, error) {
 	db := DB()
@@ -103,7 +103,7 @@ func DeleteCategory(id int) (bool, error) {
 }
 
 // UpdateCategory updates category details base on the values sent
-// takes the user id and user struct containing details to be update
+// takes the category id and category struct containing details to be update
 func UpdateCategoryById(id int, category *Category) (bool, error) {
 	db := DB()
 

--- a/models/category.go
+++ b/models/category.go
@@ -30,7 +30,6 @@ func GetAllCategory() ([]Category, error) {
 	if err != nil {
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
 		return nil, errMsg
-
 	}
 
 	for rows.Next() {
@@ -124,11 +123,9 @@ func UpdateCategoryById(id int, category *Category) (bool, error) {
 	}
 
 	query := helpers.UpdateBuilder(categoryValues, "CATEGORIES")
-	fmt.Println(query)
 	_, UpdateErr := db.Exec(query, id)
 	if UpdateErr != nil {
 		return false, UpdateErr
 	}
-
 	return true, nil
 }

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -15,7 +15,7 @@ type Recipe struct {
 	Name        string `json:"name,omitempty"`
 	UserID      string `json:"userID,omitempty"`
 	CategoryID  string `json:"catergoryID,omitempty"`
-	Description string `json:"description,omitempty"`
+	Description string `json:"description"`
 	CreatedAt   string `json:"created_at,omitempty"`
 	UpdatedAt   string `json:"updated_at,omitempty"`
 }
@@ -49,12 +49,13 @@ func GetAllRecipe() []Recipe {
 // GetRecipe gets a single recipe
 func GetRecipe(id int) (Recipe, error) {
 	db := DB()
+	defer db.Close()
 	recipe := Recipe{}
-	db.Close()
 
-	err := db.QueryRow(`SELECT name, userID, categoryID, description, created_at, 
-		updated_at FROM recipes where id = ? `, id).Scan(&recipe)
-
+	err := db.QueryRow(`SELECT id, name, userID, categoryID, description, created_at, 
+		updated_at FROM recipes where id = ? `, id).
+		Scan(&recipe.ID, &recipe.Name, &recipe.UserID,
+			&recipe.CategoryID, &recipe.Description, &recipe.CreatedAt, &recipe.UpdatedAt)
 	switch {
 	case err == sql.ErrNoRows:
 		fmt.Println("No rows with that id found", err.Error())

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"recipe/helpers"
+	"strings"
 )
 
 // Recipe data to be sent
@@ -69,15 +70,26 @@ func GetRecipe(id int) (Recipe, error) {
 }
 
 // CreateRecipe creates a new recipe
-func CreateRecipe() {
+func CreateRecipe(recipe *Recipe) (*Recipe, error) {
 	db := DB()
-	recipe := Recipe{}
+	defer db.Close()
+	fmt.Println(recipe)
 	sql := `INSERT INTO recipes (name, userID, categoryID, description) VALUES(?, ?, ?, ?)`
-	row, err := db.Exec(sql, &recipe)
-	if err != nil {
-		fmt.Println(err.Error())
+	_, err := db.Exec(sql, &recipe.Name, &recipe.UserID, &recipe.CategoryID, &recipe.Description)
+
+	switch {
+	case err != nil && strings.Contains(err.Error(), "categoryID"):
+		errMsg := fmt.Errorf("Error creating a recipe: %s", "category does not exist")
+		return recipe, errMsg
+	case err != nil && strings.Contains(err.Error(), "userID"):
+		errMsg := fmt.Errorf("Error creating a recipe: %s", "user does not exist")
+		return recipe, errMsg
+	case err != nil:
+		errMsg := fmt.Errorf("Error creating a recipe: %s", err.Error())
+		return recipe, errMsg
+	default:
+		return recipe, nil
 	}
-	fmt.Println(row)
 }
 
 // DeleteRecipe recipe from database

--- a/models/seed.go
+++ b/models/seed.go
@@ -59,6 +59,7 @@ func CreateTables(*sql.DB) {
 			userID int,
 			categoryID int,
 			description text(300),
+			image_url text,
 			created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 			updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 			PRIMARY KEY (id)

--- a/models/user.go
+++ b/models/user.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log"
+	"recipe/helpers"
 )
 
 // User data to be sent
@@ -90,16 +91,13 @@ func DeleteUser(id int) (bool, error) {
 	db := DB()
 
 	defer db.Close()
-	_, getErr := GetUser(id)
 
-	if getErr != nil {
-		return false, getErr
-	}
 	sql := `DELETE FROM users WHERE id = ?`
 	_, err := db.Exec(sql, id)
 
 	if err != nil {
-		return false, err
+		errMsg := fmt.Errorf("Error Deletin a category: %s?", err.Error())
+		return false, errMsg
 	}
 	return true, nil
 }
@@ -132,12 +130,12 @@ func UpdateUserByID(id int, user *User) (bool, error) {
 	if user.Email != "" {
 		userValues["email"] = user.Email
 	}
-	// table := "USERS"
-	// query := helpers.UpdateBuilder(userValues, table)
+	table := "USERS"
+	query := helpers.UpdateBuilder(userValues, table)
 
-	// _, UpdateErr := db.Exec(query, id)
-	// if UpdateErr != nil {
-	// 	return false, UpdateErr
-	// }
+	_, UpdateErr := db.Exec(query, id)
+	if UpdateErr != nil {
+		return false, UpdateErr
+	}
 	return true, nil
 }

--- a/schema.sql
+++ b/schema.sql
@@ -47,3 +47,4 @@ ALTER TABLE recipes
 
 ALTER TABLE recipes
 			ADD FOREIGN KEY (ingredientID) REFERENCES ingredients(id);
+


### PR DESCRIPTION
### WHAT DOES THIS PR DO
  This PR adds user controller to the recipe ENDPOINT
#### SUMMARY
  Users can now GET, DELETE, UPDATE AND CREATE recipes via HTTP. Endpoints implemented is stated below
- GET        /api/v1/recipes gets all recipes
- POST     /api/v1/recipes creates a new recipes
- GET        /api/v1/recipes/id gets a single recipes
- PUT        /api/v1/recipes/id updates a single recipes 
- DELETE  /api/v1/recipes/id deletes a single recipes 
### Dev Notes 
 A new ticket would be added later to further expand on this controller to allow 
- Search for recipes
- limit the number of results fo getting all recipes
- paginate the list of recipes