### PR TITLE
Feature(ingredients endpoints) Add controllers for ingredients

### DIFF
--- a/controllers/ingredients.go
+++ b/controllers/ingredients.go
@@ -1,0 +1,139 @@
+package controllers
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"recipe/helpers"
+	"recipe/models"
+	"strconv"
+
+	_ "github.com/go-sql-driver/mysql"
+	"github.com/gorilla/mux"
+)
+
+// IngredientResponse is
+type IngredientResponse struct {
+	Status int                 `json:"status"`
+	Data   []models.Ingredient `json:"data"`
+}
+
+// CreateIngredient creates a new Ingredient
+func CreateIngredient(w http.ResponseWriter, r *http.Request) {
+	Ingredient := models.Ingredient{
+		Name:     r.FormValue("name"),
+		Quantity: r.FormValue("quantity"),
+		RecipeID: r.FormValue("recipeID"),
+		Unit:     r.FormValue("unit"),
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoderErr := decoder.Decode(&Ingredient)
+
+	if decoderErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	if Ingredient.Name == "" || Ingredient.Quantity == "" || Ingredient.RecipeID == "" {
+		errMsg := models.Ingredient{
+			Name:     "Name  is required",
+			Quantity: "quantity id is required",
+			RecipeID: "recipeID id is required",
+		}
+		type Error struct {
+			Status  int
+			Message interface{}
+		}
+		newError := Error{Status: http.StatusBadRequest, Message: errMsg}
+		response, _ := json.Marshal(newError)
+		helpers.ResponseWriter(w, http.StatusBadRequest, string(response))
+		return
+	}
+	_, dbErr := models.CreateIngredient(&Ingredient)
+
+	if dbErr != nil {
+		helpers.ServerError(w, dbErr)
+		return
+	}
+	helpers.StatusOkMessage(w, "Ingredient created")
+}
+
+// GetIngredient Gets all Ingredient and sends the data as response
+// to the requesting Ingredient
+func GetIngredient(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	Ingredient, err := models.GetIngredient(id)
+	if err != nil {
+		helpers.StatusNotFound(w, err)
+		return
+	}
+	helpers.StatusOk(w, Ingredient)
+}
+
+// GetAllIngredient Gets all Ingredient and sends the data as response
+// to the requesting Ingredient
+func GetAllIngredient(w http.ResponseWriter, r *http.Request) {
+	Ingredient, err := models.GetAllIngredient()
+	if err != nil {
+		helpers.ServerError(w, err)
+		return
+	}
+	response := IngredientResponse{
+		Status: http.StatusOK,
+		Data:   Ingredient,
+	}
+	result, _ := json.Marshal(response)
+
+	helpers.ResponseWriter(w, http.StatusOK, string(result))
+}
+
+//UpdateIngredient updates Ingredient's details
+func UpdateIngredient(w http.ResponseWriter, r *http.Request) {
+	Ingredient := models.Ingredient{
+		Name:     r.FormValue("name"),
+		RecipeID: r.FormValue("RecipeID"),
+		Quantity: r.FormValue("quantity"),
+		Unit:     r.FormValue("unit"),
+	}
+	decoder := json.NewDecoder(r.Body)
+	decoderErr := decoder.Decode(&Ingredient)
+
+	if decoderErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	vars := mux.Vars(r)
+	id, _ := strconv.Atoi(vars["id"])
+
+	fmt.Println(id)
+
+	_, err := models.UpdateIngredient(id, &Ingredient)
+	if err != nil {
+		helpers.BadRequest(w, errors.New(err.Error()))
+		return
+	}
+
+	helpers.StatusOkMessage(w, "Ingredient updated")
+}
+
+// DeleteIngredient deletes an Ingredient
+func DeleteIngredient(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+
+	id, parseErr := strconv.Atoi(vars["id"])
+	if parseErr != nil {
+		helpers.DecoderErrorResponse(w)
+		return
+	}
+	_, err := models.DeleteIngredient(id)
+	if err != nil {
+		helpers.BadRequest(w, err)
+		return
+	}
+	helpers.StatusOkMessage(w, "Ingredient deleted")
+}

--- a/main/main.go
+++ b/main/main.go
@@ -41,5 +41,11 @@ func routes() *mux.Router {
 	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.UpdateRecipe).Methods("PUT")
 	router.HandleFunc(baseURL+"/recipes/{id:[0-9]+}", controllers.DeleteRecipe).Methods("DELETE")
 
+	router.HandleFunc(baseURL+"/ingredients", controllers.GetAllIngredient).Methods("GET")
+	router.HandleFunc(baseURL+"/ingredients", controllers.CreateIngredient).Methods("POST")
+	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.GetIngredient).Methods("GET")
+	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.UpdateIngredient).Methods("PUT")
+	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.DeleteIngredient).Methods("DELETE")
+
 	return router
 }

--- a/models/category.go
+++ b/models/category.go
@@ -3,7 +3,6 @@ package models
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"recipe/helpers"
 )
 
@@ -62,7 +61,6 @@ func GetCategory(id int) (Category, error) {
 		errMsg := fmt.Errorf("category with (id %d) does not exist", id)
 		return category, errMsg
 	case err != nil:
-		log.Fatal("An error occurred", err.Error())
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
 		return category, errMsg
 	default:

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -3,7 +3,6 @@ package models
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"recipe/helpers"
 	"strings"
 )
@@ -62,7 +61,6 @@ func GetRecipe(id int) (Recipe, error) {
 		errMsg := fmt.Errorf("recipe with (id %d) does not exist", id)
 		return recipe, errMsg
 	case err != nil:
-		log.Fatal("An error occurred", err.Error())
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
 		return recipe, errMsg
 	default:
@@ -100,14 +98,11 @@ func DeleteRecipe(id int) (bool, error) {
 	db := DB()
 	defer db.Close()
 	sql := `DELETE * FROM recipes WHERE id = ?`
-	row, err := db.Exec(sql, id)
+	_, err := db.Exec(sql, id)
 
 	if err != nil {
-		fmt.Println(err.Error())
 		return false, err
 	}
-	fmt.Println(row)
-
 	return true, nil
 }
 

--- a/models/user.go
+++ b/models/user.go
@@ -3,7 +3,6 @@ package models
 import (
 	"database/sql"
 	"fmt"
-	"log"
 	"recipe/helpers"
 )
 
@@ -60,7 +59,6 @@ func GetUser(id int) (User, error) {
 		errMsg := fmt.Errorf("user with (id %d) does not exist", id)
 		return user, errMsg
 	case err != nil:
-		log.Fatal("An error occurred", err.Error())
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
 		return user, errMsg
 	default:


### PR DESCRIPTION
### WHAT DOES THIS PR DO
  This PR adds user controller for the ingredients endpoint
#### SUMMARY
  Users can now GET, DELETE, UPDATE AND CREATE other categories via HTTP. Endpoints implemented are stated below
- GET        /api/v1/categories gets all ingredients
- POST     /api/v1/categories creates a new ingredient
- GET        /api/v1/categories/id gets a single ingredient
- PUT        /api/v1/categories/id updates a single ingredient 
- DELETE  /api/v1/categories/id deletes a single ingredient 
### Dev Notes 
 A new ticket would be added later to further expand on this controller to allow 
- Search for ingredients
- limit the number of results fo get all ingredients
- paginate the list of ingredients