### PR TITLE
Add pagination meta-data to get All request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 pkg
 .DS_Store
 node_modules
+test

--- a/controllers/ingredients.go
+++ b/controllers/ingredients.go
@@ -15,8 +15,9 @@ import (
 
 // IngredientResponse is
 type IngredientResponse struct {
-	Status int                 `json:"status"`
-	Data   []models.Ingredient `json:"data"`
+	Status   int                 `json:"status"`
+	MetaData interface{}         `json:"meta_data,omitempty"`
+	Data     []models.Ingredient `json:"data"`
 }
 
 // CreateIngredient creates a new Ingredient
@@ -78,14 +79,22 @@ func GetIngredient(w http.ResponseWriter, r *http.Request) {
 // GetAllIngredient Gets all Ingredient and sends the data as response
 // to the requesting Ingredient
 func GetAllIngredient(w http.ResponseWriter, r *http.Request) {
-	Ingredient, err := models.GetAllIngredient()
+	query, err := helpers.GetQuery(r)
 	if err != nil {
 		helpers.ServerError(w, err)
 		return
 	}
+	ingredient, count, err := models.GetAllIngredient(&query)
+	if err != nil {
+		helpers.ServerError(w, err)
+		return
+	}
+	metaData := helpers.MetaData(count, len(ingredient), &query)
+
 	response := IngredientResponse{
-		Status: http.StatusOK,
-		Data:   Ingredient,
+		Status:   http.StatusOK,
+		MetaData: metaData,
+		Data:     ingredient,
 	}
 	result, _ := json.Marshal(response)
 
@@ -109,8 +118,6 @@ func UpdateIngredient(w http.ResponseWriter, r *http.Request) {
 	}
 	vars := mux.Vars(r)
 	id, _ := strconv.Atoi(vars["id"])
-
-	fmt.Println(id)
 
 	_, err := models.UpdateIngredient(id, &Ingredient)
 	if err != nil {

--- a/controllers/ingredients.go
+++ b/controllers/ingredients.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"recipe/helpers"
 	"recipe/models"

--- a/controllers/recipe.go
+++ b/controllers/recipe.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"recipe/helpers"
 	"recipe/models"

--- a/controllers/user.go
+++ b/controllers/user.go
@@ -16,8 +16,9 @@ import (
 )
 
 type usersResponse struct {
-	Status int           `json:"status"`
-	Data   []models.User `json:"data"`
+	Status   int           `json:"status"`
+	MetaData interface{}   `json:"meta_data,omitempty"`
+	Data     []models.User `json:"data"`
 }
 
 // CreateUser creates a new user
@@ -88,14 +89,22 @@ func GetUser(w http.ResponseWriter, r *http.Request) {
 // GetAllUsers Gets all users and sends the data as response
 // to the requesting user
 func GetAllUsers(w http.ResponseWriter, r *http.Request) {
-	users, err := models.GetAllUser()
+	query, err := helpers.GetQuery(r)
 	if err != nil {
 		helpers.ServerError(w, err)
 		return
 	}
+	users, count, err := models.GetAllUser(query)
+	if err != nil {
+		helpers.ServerError(w, err)
+		return
+	}
+	metaData := helpers.MetaData(count, len(users), &query)
+
 	response := usersResponse{
-		Status: http.StatusOK,
-		Data:   users,
+		Status:   http.StatusOK,
+		MetaData: metaData,
+		Data:     users,
 	}
 	result, _ := json.Marshal(response)
 

--- a/helpers/customHandler.go
+++ b/helpers/customHandler.go
@@ -70,3 +70,4 @@ func IsValidEmail(email string) bool {
 	}
 	return true
 }
+

--- a/helpers/query.go
+++ b/helpers/query.go
@@ -2,10 +2,30 @@ package helpers
 
 import (
 	"bytes"
+	"database/sql"
+	"errors"
 	"fmt"
+	"math"
+	"net/http"
+	"strconv"
 )
 
-// UpdateBuilder
+// Query params for pagination
+type Query struct {
+	Limit  int    `json:"limit"`
+	Offset int    `json:"offset"`
+	Q      string `json:"q"`
+}
+
+// Pagination  metadata
+type Pagination struct {
+	PageCount   int `json:"page_count"`
+	CurrentPage int `json:"current_page"`
+	PageSize    int `json:"page_size"`
+	TotalCount  int `json:"total_count"`
+}
+
+// UpdateBuilder generates update query dynamically
 func UpdateBuilder(u map[string]string, table string) string {
 	var query bytes.Buffer
 	query.WriteString("UPDATE " + table + " SET ")
@@ -25,4 +45,78 @@ func UpdateBuilder(u map[string]string, table string) string {
 	fmt.Println(query.String())
 	result = query.String()
 	return result
+}
+
+// GetCount get user count
+func GetCount(db *sql.DB, table string) (int, error) {
+	var count int
+
+	row, countErr := db.Query(`SELECT COUNT(*) as count FROM ` + table)
+	if countErr != nil {
+		errMsg := fmt.Errorf("an unknown error occurred %s", countErr.Error())
+		return 0, errMsg
+	}
+
+	for row.Next() {
+		scanErr := row.Scan(&count)
+		if scanErr != nil {
+			errMsg := fmt.Errorf("an unknown error occurred %s", scanErr.Error())
+			return 0, errMsg
+		}
+	}
+	return count, nil
+}
+
+// MetaData creates meta_data for pagination
+func MetaData(count int, rowsLength int, query *Query) interface{} {
+	next := math.Ceil(float64(count) / float64(query.Limit))
+	fmt.Println(strconv.Itoa(count))
+	fmt.Println(strconv.Itoa(query.Limit))
+
+	currentPage := math.Floor(float64(query.Offset/query.Limit) + 1)
+
+	pagination := Pagination{
+		PageCount:   int(next),
+		CurrentPage: int(currentPage),
+		PageSize:    rowsLength,
+		TotalCount:  count,
+	}
+	return pagination
+}
+
+// GetQuery gets user query
+func GetQuery(r *http.Request) (Query, error) {
+
+	query := Query{}
+
+	formLimit := r.FormValue("limit")
+	formOffset := r.FormValue("offset")
+	formQ := r.FormValue("q")
+
+	if formLimit != "" {
+		limit, err := strconv.Atoi(formLimit)
+		if err != nil {
+			return query, errors.New("Invalid limit")
+		}
+		query.Limit = limit
+	} else {
+		query.Limit = 10
+	}
+
+	if formOffset != "" {
+		offset, err := strconv.Atoi(formOffset)
+		if err != nil {
+			return query, errors.New("Invalid offset")
+		}
+		query.Offset = offset
+	} else {
+		query.Offset = 0
+	}
+
+	if formQ != "" {
+		query.Q = formQ
+	}
+
+	return query, nil
+
 }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -151,7 +151,7 @@ func Decode(jwt string, secret string) (interface{}, error) {
 
 	// verifies if the header and signature is exactly whats in
 	// the signature
-	if CompareHmac(signatureValue, token[2], "hello") == false {
+	if CompareHmac(signatureValue, token[2], secret) == false {
 		return nil, errors.New("Invalid token")
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -46,6 +46,6 @@ func routes() *mux.Router {
 	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.GetIngredient).Methods("GET")
 	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.UpdateIngredient).Methods("PUT")
 	router.HandleFunc(baseURL+"/ingredients/{id:[0-9]+}", controllers.DeleteIngredient).Methods("DELETE")
-
+	
 	return router
 }

--- a/models/category.go
+++ b/models/category.go
@@ -33,8 +33,7 @@ func GetAllCategory(query helpers.Query) ([]Category, int, error) {
 			LIMIT ` + limit + ` OFFSET ` + offset
 	} else {
 		dbQuery = `SELECT id, title, description, created_at, updated_at FROM categories 
-			WHERE title ILIKE %` + query.Q + `% ` +
-			` LIMIT = ` + limit + ` OFFSET = ` + offset
+			WHERE title LIKE '%` + query.Q + `%'`
 	}
 	rows, err := db.Query(dbQuery)
 	if err != nil {

--- a/models/category.go
+++ b/models/category.go
@@ -4,31 +4,42 @@ import (
 	"database/sql"
 	"fmt"
 	"recipe/helpers"
+	"strconv"
 )
 
 // Category data to be sent
 // When request is made to the server
 type Category struct {
-	ID          int    `json:"id,omitempty"`
-	Title       string `json:"title,omitempty"`
-	Description string `json:"description"`
-	CreatedAt   string `json:"created_at,omitempty"`
-	UpdatedAt   string `json:"updated_at,omitempty"`
+	MetaData    interface{} `json:"meta_data,omitempty"`
+	ID          int         `json:"id,omitempty"`
+	Title       string      `json:"title,omitempty"`
+	Description string      `json:"description"`
+	CreatedAt   string      `json:"created_at,omitempty"`
+	UpdatedAt   string      `json:"updated_at,omitempty"`
 }
 
 // GetAllCategory gets all category
-func GetAllCategory() ([]Category, error) {
+func GetAllCategory(query helpers.Query) ([]Category, int, error) {
 	db := DB()
 
 	defer db.Close()
 
+	limit := strconv.Itoa(query.Limit)
+	offset := strconv.Itoa(query.Offset)
+	var dbQuery string
 	categories := []Category{}
-
-	rows, err := db.Query(`SELECT id, title, description, created_at, updated_at FROM categories`)
-
+	if query.Q == "" {
+		dbQuery = `SELECT id, title, description, created_at, updated_at FROM categories
+			LIMIT ` + limit + ` OFFSET ` + offset
+	} else {
+		dbQuery = `SELECT id, title, description, created_at, updated_at FROM categories 
+			WHERE title ILIKE %` + query.Q + `% ` +
+			` LIMIT = ` + limit + ` OFFSET = ` + offset
+	}
+	rows, err := db.Query(dbQuery)
 	if err != nil {
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
-		return nil, errMsg
+		return nil, 0, errMsg
 	}
 
 	for rows.Next() {
@@ -36,12 +47,16 @@ func GetAllCategory() ([]Category, error) {
 
 		if err := rows.Scan(&category.ID, &category.Title, &category.Description, &category.CreatedAt, &category.UpdatedAt); err != nil {
 			errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
-			return nil, errMsg
+			return nil, 0, errMsg
 		}
 		categories = append(categories, category)
-		fmt.Println(categories)
 	}
-	return categories, nil
+	count, countErr := helpers.GetCount(db, "categories")
+	if countErr != nil {
+		errMsg := fmt.Errorf("an unknown error occurred %s", countErr.Error())
+		return nil, 0, errMsg
+	}
+	return categories, count, nil
 }
 
 //GetCategory gets a single category
@@ -57,7 +72,6 @@ func GetCategory(id int) (Category, error) {
 
 	switch {
 	case err == sql.ErrNoRows:
-		fmt.Println("No category with that id found", err.Error())
 		errMsg := fmt.Errorf("category with (id %d) does not exist", id)
 		return category, errMsg
 	case err != nil:
@@ -101,7 +115,7 @@ func DeleteCategory(id int) (bool, error) {
 
 // UpdateCategory updates category details base on the values sent
 // takes the category id and category struct containing details to be update
-func UpdateCategoryById(id int, category *Category) (bool, error) {
+func UpdateCategory(id int, category *Category) (bool, error) {
 	db := DB()
 
 	defer db.Close()

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"recipe/helpers"
+	"strconv"
 	"strings"
 )
 
@@ -21,29 +22,37 @@ type Recipe struct {
 }
 
 // GetAllRecipe gets all recipe
-func GetAllRecipe() ([]Recipe, error) {
+func GetAllRecipe(query helpers.Query) ([]Recipe, int, error) {
 	db := DB()
 	defer db.Close()
 
 	recipes := []Recipe{}
-
-	rows, err := db.Query(`SELECT id, name, userID, categoryID, description, image_url, created_at, updated_at FROM recipes`)
-
+	limit := strconv.Itoa(query.Limit)
+	offset := strconv.Itoa(query.Offset)
+	var dbQuery string
+	if query.Q == "" {
+		dbQuery = `SELECT id, name, userID, categoryID, description, image_url, created_at, updated_at FROM recipes
+			LIMIT ` + limit + ` OFFSET ` + offset
+	} else {
+		dbQuery = `SELECT id, name, userID, categoryID, description, image_url, created_at, updated_at FROM recipes
+			WHERE title ILIKE %` + query.Q + `% ` +
+			` LIMIT = ` + limit + ` OFFSET = ` + offset
+	}
+	rows, err := db.Query(dbQuery)
 	if err != nil {
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
-		return nil, errMsg
+		return nil, 0, errMsg
 	}
 	for rows.Next() {
 		recipe := Recipe{}
 		if err := rows.Scan(&recipe.ID, &recipe.Name, &recipe.UserID,
 			&recipe.CategoryID, &recipe.Description, &recipe.Image, &recipe.CreatedAt, &recipe.UpdatedAt); err != nil {
 			errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
-			return nil, errMsg
+			return nil, 0, errMsg
 		}
 		recipes = append(recipes, recipe)
-		fmt.Println(recipe)
 	}
-	return recipes, nil
+	return recipes, 0, nil
 }
 
 // GetRecipe gets a single recipe
@@ -57,8 +66,7 @@ func GetRecipe(id int) (Recipe, error) {
 			&recipe.CategoryID, &recipe.Description, &recipe.Image, &recipe.CreatedAt, &recipe.UpdatedAt)
 	switch {
 	case err == sql.ErrNoRows:
-		fmt.Println("No rows with that id found", err.Error())
-		errMsg := fmt.Errorf("recipe with (id %d) does not exist", id)
+]		errMsg := fmt.Errorf("recipe with (id %d) does not exist", id)
 		return recipe, errMsg
 	case err != nil:
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())
@@ -72,7 +80,6 @@ func GetRecipe(id int) (Recipe, error) {
 func CreateRecipe(recipe *Recipe) (*Recipe, error) {
 	db := DB()
 	defer db.Close()
-	fmt.Println(recipe)
 	sql := `INSERT INTO recipes (name, userID, categoryID, description, image_url) VALUES(?, ?, ?, ?, ?)`
 	_, err := db.Exec(sql, &recipe.Name, &recipe.UserID, &recipe.CategoryID, &recipe.Description, &recipe.Image)
 

--- a/models/recipe.go
+++ b/models/recipe.go
@@ -35,8 +35,8 @@ func GetAllRecipe(query helpers.Query) ([]Recipe, int, error) {
 			LIMIT ` + limit + ` OFFSET ` + offset
 	} else {
 		dbQuery = `SELECT id, name, userID, categoryID, description, image_url, created_at, updated_at FROM recipes
-			WHERE title ILIKE %` + query.Q + `% ` +
-			` LIMIT = ` + limit + ` OFFSET = ` + offset
+			WHERE title LIKE %` + query.Q + `%'` +
+
 	}
 	rows, err := db.Query(dbQuery)
 	if err != nil {
@@ -66,7 +66,7 @@ func GetRecipe(id int) (Recipe, error) {
 			&recipe.CategoryID, &recipe.Description, &recipe.Image, &recipe.CreatedAt, &recipe.UpdatedAt)
 	switch {
 	case err == sql.ErrNoRows:
-]		errMsg := fmt.Errorf("recipe with (id %d) does not exist", id)
+		errMsg := fmt.Errorf("recipe with (id %d) does not exist", id)
 		return recipe, errMsg
 	case err != nil:
 		errMsg := fmt.Errorf("an unknown error occurred %s", err.Error())

--- a/schema.sql
+++ b/schema.sql
@@ -48,3 +48,7 @@ ALTER TABLE recipes
 ALTER TABLE recipes
 			ADD FOREIGN KEY (ingredientID) REFERENCES ingredients(id);
 
+limit := 10
+OFFSET := 0
+
+"SELECT * FROM Orders LIMIT 10 OFFSET 10 "

--- a/test/main.go
+++ b/test/main.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	// cannot be reassigned
+	const hello = "Hello"
+
+	// declare a variable in golan
+	var world string
+	//others
+	// int
+	// int32
+	// int64 this three integers also have a float counterpart
+
+	// assigning a variable
+	world = "guest"
+
+	// go offers dynamic assignment
+	geetings := " have a wonder full weekend"
+	if len(os.Args) > 1 {
+		fmt.Println(hello + " " + os.Args[1] + geetings)
+	} else {
+		fmt.Println(hello + " " + world + geetings)
+	}
+}


### PR DESCRIPTION
### WHAT DOES THIS PR DO
 This PR adds pagination metadata to getAll request
#### SUMMARY
  This PR allows users to limit, offset and query gellAll request for the endpoint below
- GET        /api/v1/categories gets all categories
   - /api/v1/categories?limt=10&offset=10
- GET        /api/v1/ingredients gets all ingredients
   - /api/v1/ingredients?limt=10&offset=10
- GET        /api/v1/users gets all users
   - /api/v1/users?limt=10&offset=10
- GET        /api/v1/recipes gets all recipes
   - /api/v1/recipes?limt=10&offset=10
